### PR TITLE
Upgrade Karpenter to latest version to comply with K8s 1.32

### DIFF
--- a/addon-dependent-resources/vendors/aws/templates/karpenter/node-classes.yaml
+++ b/addon-dependent-resources/vendors/aws/templates/karpenter/node-classes.yaml
@@ -3,7 +3,7 @@ kind: EC2NodeClass
 metadata:
   name: "default-x86"
 spec:
-  amiFamily: AL2
+  amiFamily: AL2023
   role: "karpenter-{{ .Values.karpenter.settings.clusterName }}" 
   subnetSelectorTerms:
     - tags:
@@ -26,7 +26,7 @@ kind: EC2NodeClass
 metadata:
   name: "default-arm64"
 spec:
-  amiFamily: AL2
+  amiFamily: AL2023
   role: "karpenter-{{ .Values.karpenter.settings.clusterName }}" 
   subnetSelectorTerms:
     - tags:

--- a/argocd/addons/vendors/aws/addons-aws-oss-karpenter-appset.yaml
+++ b/argocd/addons/vendors/aws/addons-aws-oss-karpenter-appset.yaml
@@ -16,7 +16,7 @@ spec:
                 addonChart: karpenter
                 addonChartReleaseName: karpenter
                 addonChartRepositoryNamespace: karpenter
-                addonChartVersion: 1.1.2
+                addonChartVersion: 1.3.2
                 # using oci repostory already configure in argocd
                 # argocd repo add public.ecr.aws --type helm --name aws-public-ecr --enable-oci
                 addonChartRepository: public.ecr.aws
@@ -30,13 +30,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 1.1.2
+                addonChartVersion: 1.3.2
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 1.1.2
+                addonChartVersion: 1.3.2
   template:
     metadata:
       name: addon-{{.name}}-{{.values.addonChart}}


### PR DESCRIPTION
When putting load on the K8s blueprint, I figured out that the current Karpenter version 1.1.2 is not compliant with Kubernetes version. Therefore, I needed to upgrade it. Additionally, the nodepool AL2 is deprecated and is replaced with AL2023. 